### PR TITLE
Set up logo testing page

### DIFF
--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -65,12 +65,3 @@
 
   </div>
 </div>
-
-<script>
-  (function() {
-    var HIGHEST_IMAGE_NUMBER = 5;
-    var logoNum = Math.ceil(Math.random() * HIGHEST_IMAGE_NUMBER);
-    var logoObj = '<object type="image/svg+xml" data="/assets/images/logo' + logoNum + '.svg" class="logo"></object>';
-    document.querySelector('.logo-wrapper').innerHTML = logoObj;
-  })();
-</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -40,6 +40,15 @@ navigation:
     </header>
 
     {% include logo.html %}
+    <script>
+      (function(d) {
+        var HIGHEST_SCRIPT_NUMBER = 5;
+        var logoNum = Math.ceil(Math.random() * HIGHEST_SCRIPT_NUMBER);
+        var scriptEl = d.createElement('script');
+        scriptEl.src = '/assets/images/logo' + logoNum + '.js';
+        d.querySelector('.logo-wrapper').appendChild(scriptEl);
+      })(document);
+    </script>
 
     <div class="page-content">
       {% if page.is_post %}

--- a/_pages/logo-dev.html
+++ b/_pages/logo-dev.html
@@ -1,0 +1,42 @@
+{% include logo.html %}
+
+<script id="script-to-execute"></script>
+
+<form id="test-form">
+  <p>
+    <label>Script to test:
+      <input id="script-filename" name="script-filename"
+        type="url" required
+        value="/assets/js/logo/logo-script1.js" list="known-scripts">
+
+        <datalist id="known-scripts">
+          <option value="/assets/js/logo/logo-script1.js">
+          <option value="/assets/js/logo/logo-script2.js">
+          <option value="/assets/js/logo/logo-script3.js">
+          <option value="/assets/js/logo/logo-script4.js">
+        </datalist>
+    </label>
+
+    <button>Run Code</button>
+  </p>
+
+  <p>
+    <output name="status-message"></output>
+  </p>
+</form>
+
+<script>
+  (function(d) {
+    var formEl = d.getElementById('test-form'),
+      urlInput = d.getElementById('script-filename').value,
+      scriptEl = d.getElementById('script-to-execute');
+
+    function executeScript(event) {
+      scriptEl.src = urlInput.trim();
+      event.preventDefault();
+      return false;
+    }
+
+    formEl.addEventListener('submit', executeScript);
+  })(document);
+</script>

--- a/assets/js/logo/logo-script1.js
+++ b/assets/js/logo/logo-script1.js
@@ -1,0 +1,60 @@
+(function() {
+  var hoverGradients = ['logo-radial-gradient0', 'logo-radial-gradient1', 'logo-radial-gradient2'];
+  var hoverGradientEls = {
+    'logo-radial-gradient0': document.getElementById('logo-radial-gradient0'),
+    'logo-radial-gradient1': document.getElementById('logo-radial-gradient1'),
+    'logo-radial-gradient2': document.getElementById('logo-radial-gradient2')
+  };
+  var logoMaskBox = document.getElementById('logo-mask-box');
+  var logoStrokeBox = document.getElementById('logo-stroke-box');
+  var DEFAULT_FILL_VALUE = 'url(#logo-linear-gradient)';
+  var activeGradientNum = 0;
+
+  logoMaskBox.addEventListener('mouseenter', setHoverGradient);
+  logoMaskBox.addEventListener('mousemove', positionHoverGradient);
+  logoMaskBox.addEventListener('mouseleave', setDefaultGradient);
+  logoMaskBox.addEventListener('click', toggleGradient);
+
+  function getHoverFillValue() {
+    return 'url(#' + hoverGradients[activeGradientNum] + ')';
+  }
+
+  function positionHoverGradient(event) {
+    var currentGradientEl = hoverGradientEls[hoverGradients[activeGradientNum]],
+        clientRect = logoMaskBox.getBoundingClientRect(),
+        svgX = event.x - clientRect.left,
+        svgY = event.y - clientRect.top,
+        percentX = Math.round(100 * (svgX / clientRect.width)),
+        percentY = Math.round(100 * (svgY / clientRect.height));
+
+    /**
+     * We set percentages instead of units because that
+     * works best across various SVG scaling scenarios.
+     */
+    currentGradientEl.fx.baseVal.valueAsString = '' + percentX + '%';
+    currentGradientEl.fy.baseVal.valueAsString = '' + percentY + '%';
+    currentGradientEl.cx.baseVal.valueAsString = '' + percentX + '%';
+    currentGradientEl.cy.baseVal.valueAsString = '' + percentY + '%';
+  }
+
+  function setHoverGradient() {
+    logoMaskBox.style.fill = getHoverFillValue();
+    logoStrokeBox.style.stroke = getHoverFillValue();
+  }
+
+  function setDefaultGradient(event) {
+    logoMaskBox.style.fill = DEFAULT_FILL_VALUE;
+    logoStrokeBox.style.stroke = DEFAULT_FILL_VALUE;
+  }
+
+  function toggleGradient(event) {
+    if (activeGradientNum === hoverGradients.length - 1) {
+      activeGradientNum = 0;
+    } else {
+      activeGradientNum++;
+    }
+    setHoverGradient();
+    positionHoverGradient(event);
+  }
+
+})();

--- a/assets/js/logo/logo-script2.js
+++ b/assets/js/logo/logo-script2.js
@@ -1,0 +1,93 @@
+(function() {
+  var hoverGradients = ['logo-radial-gradient0', 'logo-radial-gradient1', 'logo-radial-gradient2'];
+  var hoverGradientEls = {
+    'logo-radial-gradient0': document.getElementById('logo-radial-gradient0'),
+    'logo-radial-gradient1': document.getElementById('logo-radial-gradient1'),
+    'logo-radial-gradient2': document.getElementById('logo-radial-gradient2')
+  };
+  var logoMaskBox = document.getElementById('logo-mask-box');
+  var logoStrokeBox = document.getElementById('logo-stroke-box');
+  var bryan = document.getElementById('Bryan');
+  var braun = document.getElementById('Braun');
+  var letters = Array.from(bryan.children).concat(Array.from(braun.children));
+  var DEFAULT_FILL_VALUE = 'url(#logo-linear-gradient)';
+  var activeGradientNum = 0;
+
+  logoMaskBox.addEventListener('mouseenter', setHoverGradient);
+  logoMaskBox.addEventListener('mousemove', positionHoverGradient);
+  logoMaskBox.addEventListener('mouseleave', setDefaultGradient);
+  logoMaskBox.addEventListener('click', toggleGradient);
+  logoMaskBox.addEventListener('mouseenter', quakeSet);
+  logoMaskBox.addEventListener('mousemove', quake);
+  logoMaskBox.addEventListener('mouseleave', quakeUnset);
+
+  function quakeSet() {
+    letters.forEach(function (letter) {
+      letter.style.transition = "";
+      letter.style.transformOrigin = "center";
+    });
+  }
+
+  function quake() {
+    letters.forEach(function (letter) {
+      var rt = letter.style.transform.split(/\(|\)/);
+      if (rt == "") {
+        var r = 0, tx = 0, ty = 0;
+      }
+      else {
+        var r = parseFloat(rt[1]), tx = parseFloat(rt[3]), ty = parseFloat(rt[5]);
+      }
+      letter.style.transform = 'rotate(' + (r+Math.random()/5-0.1) + 'rad) translateX(' + (tx + Math.random()*4-2) + 'px) translateY(' + (ty + Math.random()*4-2) + 'px)';
+    });
+  }
+
+  function quakeUnset() {
+    letters.forEach(function (letter) {
+      letter.style.transition = "transform 1s";
+      letter.style.transform = "";
+    });
+  }
+
+  function getHoverFillValue() {
+    return 'url(#' + hoverGradients[activeGradientNum] + ')';
+  }
+
+  function positionHoverGradient(event) {
+    var currentGradientEl = hoverGradientEls[hoverGradients[activeGradientNum]],
+        clientRect = logoMaskBox.getBoundingClientRect(),
+        svgX = event.x - clientRect.left,
+        svgY = event.y - clientRect.top,
+        percentX = Math.round(100 * (svgX / clientRect.width)),
+        percentY = Math.round(100 * (svgY / clientRect.height));
+
+    /**
+     * We set percentages instead of units because that
+     * works best across various SVG scaling scenarios.
+     */
+    currentGradientEl.fx.baseVal.valueAsString = '' + percentX + '%';
+    currentGradientEl.fy.baseVal.valueAsString = '' + percentY + '%';
+    currentGradientEl.cx.baseVal.valueAsString = '' + percentX + '%';
+    currentGradientEl.cy.baseVal.valueAsString = '' + percentY + '%';
+  }
+
+  function setHoverGradient() {
+    logoMaskBox.style.fill = getHoverFillValue();
+    logoStrokeBox.style.stroke = getHoverFillValue();
+  }
+
+  function setDefaultGradient(event) {
+    logoMaskBox.style.fill = DEFAULT_FILL_VALUE;
+    logoStrokeBox.style.stroke = DEFAULT_FILL_VALUE;
+  }
+
+  function toggleGradient(event) {
+    if (activeGradientNum === hoverGradients.length - 1) {
+      activeGradientNum = 0;
+    } else {
+      activeGradientNum++;
+    }
+    setHoverGradient();
+    positionHoverGradient(event);
+  }
+
+})();

--- a/assets/js/logo/logo-script3.js
+++ b/assets/js/logo/logo-script3.js
@@ -1,0 +1,108 @@
+(function() {
+  var hoverGradients = ['logo-radial-gradient0', 'logo-radial-gradient1', 'logo-radial-gradient2'];
+  var hoverGradientEls = {
+      'logo-radial-gradient0': document.getElementById('logo-radial-gradient0'),
+      'logo-radial-gradient1': document.getElementById('logo-radial-gradient1'),
+      'logo-radial-gradient2': document.getElementById('logo-radial-gradient2')
+  };
+  var logoMaskBox = document.getElementById('logo-mask-box');
+  var logoStrokeBox = document.getElementById('logo-stroke-box');
+  var bryan = document.getElementById('Bryan');
+  var braun = document.getElementById('Braun');
+  var letters = Array.from(bryan.children).concat(Array.from(braun.children));
+  var DEFAULT_FILL_VALUE = 'url(#logo-linear-gradient)';
+  var activeGradientNum = 0;
+  var sizeAnimationAllowed = false;
+  var timer;
+
+  logoMaskBox.addEventListener('mouseenter', setHoverGradient);
+  logoMaskBox.addEventListener('mousemove', positionHoverGradient);
+  logoMaskBox.addEventListener('mouseleave', setDefaultGradient);
+  logoMaskBox.addEventListener('click', toggleGradient);
+  logoMaskBox.addEventListener('mouseenter', startSizeAnimation);
+  logoMaskBox.addEventListener('mouseleave', stopSizeAnimation);
+
+  function startSizeAnimation() {
+    sizeAnimationAllowed = true;
+    setSize();
+  }
+
+  function stopSizeAnimation() {
+    sizeAnimationAllowed = false;
+    letters.forEach(function (letter) {
+      letter.style.transform = 'scale(1)';
+      letter.style.transformOrigin = "center";
+    });
+    clearTimeout(timer);
+  }
+
+  function setSize() {
+    if(sizeAnimationAllowed == true) {
+      letters.forEach(function (letter) {
+        var shouldLetterBeAnimated = Math.random();
+        if(shouldLetterBeAnimated > 0.75) {
+          var transforms = letter.style.transform.split(/\(|\)/);
+          var ts;
+          if (transforms == "") {
+              ts = 1;
+          } else {
+              ts = parseFloat(transforms[1]);
+          }
+          ts += (Math.random() - 0.5) * 2;
+          if (ts < 0.3) {
+              ts = 0.3;
+          } else if (ts > 2) {
+              ts = 2;
+          }
+          letter.style.transform = 'scale(' + ts + ')';
+          letter.style.transformOrigin = "center";
+        }
+      });
+
+      timer = setTimeout(function() { setSize(); }, 150);
+    }
+  }
+
+  function getHoverFillValue() {
+    return 'url(#' + hoverGradients[activeGradientNum] + ')';
+  }
+
+  function positionHoverGradient(event) {
+    var currentGradientEl = hoverGradientEls[hoverGradients[activeGradientNum]],
+        clientRect = logoMaskBox.getBoundingClientRect(),
+        svgX = event.x - clientRect.left,
+        svgY = event.y - clientRect.top,
+        percentX = Math.round(100 * (svgX / clientRect.width)),
+        percentY = Math.round(100 * (svgY / clientRect.height));
+
+    /**
+     * We set percentages instead of units because that
+     * works best across various SVG scaling scenarios.
+     */
+    currentGradientEl.fx.baseVal.valueAsString = '' + percentX + '%';
+    currentGradientEl.fy.baseVal.valueAsString = '' + percentY + '%';
+    currentGradientEl.cx.baseVal.valueAsString = '' + percentX + '%';
+    currentGradientEl.cy.baseVal.valueAsString = '' + percentY + '%';
+  }
+
+  function setHoverGradient() {
+    logoMaskBox.style.fill = getHoverFillValue();
+    logoStrokeBox.style.stroke = getHoverFillValue();
+  }
+
+  function setDefaultGradient(event) {
+    logoMaskBox.style.fill = DEFAULT_FILL_VALUE;
+    logoStrokeBox.style.stroke = DEFAULT_FILL_VALUE;
+  }
+
+  function toggleGradient(event) {
+    if (activeGradientNum === hoverGradients.length - 1) {
+      activeGradientNum = 0;
+    } else {
+      activeGradientNum++;
+    }
+    setHoverGradient();
+    positionHoverGradient(event);
+  }
+
+})();

--- a/assets/js/logo/logo-script4.js
+++ b/assets/js/logo/logo-script4.js
@@ -1,0 +1,81 @@
+(function() {
+    var hoverGradients = ['logo-radial-gradient0', 'logo-radial-gradient1', 'logo-radial-gradient2'];
+    var hoverGradientEls = {
+        'logo-radial-gradient0': document.getElementById('logo-radial-gradient0'),
+        'logo-radial-gradient1': document.getElementById('logo-radial-gradient1'),
+        'logo-radial-gradient2': document.getElementById('logo-radial-gradient2')
+    };
+    var logoMaskBox = document.getElementById('logo-mask-box');
+    var logoStrokeBox = document.getElementById('logo-stroke-box');
+    var bryan = document.getElementById('Bryan');
+    var braun = document.getElementById('Braun');
+    var letters = Array.from(bryan.children).concat(Array.from(braun.children));
+    var DEFAULT_FILL_VALUE = 'url(#logo-linear-gradient)';
+    var activeGradientNum = 0;
+
+    logoMaskBox.addEventListener('mouseenter', setHoverGradient);
+    logoMaskBox.addEventListener('mousemove', positionHoverGradient);
+    logoMaskBox.addEventListener('mouseleave', setDefaultGradient);
+    logoMaskBox.addEventListener('click', toggleGradient);
+    logoMaskBox.addEventListener('mouseenter', startSizeAnimation);
+    logoMaskBox.addEventListener('mouseleave', stopSizeAnimation);
+
+    function startSizeAnimation() {
+        letters.forEach(function (letter) {
+            letter.style.transform = 'scale(11)';
+            letter.style.transformOrigin = "center";
+            letter.style.transition = "transform 2.5s";
+        });
+    }
+
+    function stopSizeAnimation() {
+        letters.forEach(function (letter) {
+            letter.style.transform = 'scale(1)';
+            letter.style.transformOrigin = "center";
+            letter.style.transition = "transform 0.5s";
+        });
+    }
+
+    function getHoverFillValue() {
+        return 'url(#' + hoverGradients[activeGradientNum] + ')';
+    }
+
+    function positionHoverGradient(event) {
+        var currentGradientEl = hoverGradientEls[hoverGradients[activeGradientNum]],
+            clientRect = logoMaskBox.getBoundingClientRect(),
+            svgX = event.x - clientRect.left,
+            svgY = event.y - clientRect.top,
+            percentX = Math.round(100 * (svgX / clientRect.width)),
+            percentY = Math.round(100 * (svgY / clientRect.height));
+
+        /**
+         * We set percentages instead of units because that
+         * works best across various SVG scaling scenarios.
+         */
+        currentGradientEl.fx.baseVal.valueAsString = '' + percentX + '%';
+        currentGradientEl.fy.baseVal.valueAsString = '' + percentY + '%';
+        currentGradientEl.cx.baseVal.valueAsString = '' + percentX + '%';
+        currentGradientEl.cy.baseVal.valueAsString = '' + percentY + '%';
+    }
+
+    function setHoverGradient() {
+        logoMaskBox.style.fill = getHoverFillValue();
+        logoStrokeBox.style.stroke = getHoverFillValue();
+    }
+
+    function setDefaultGradient(event) {
+        logoMaskBox.style.fill = DEFAULT_FILL_VALUE;
+        logoStrokeBox.style.stroke = DEFAULT_FILL_VALUE;
+    }
+
+    function toggleGradient(event) {
+        if (activeGradientNum === hoverGradients.length - 1) {
+            activeGradientNum = 0;
+        } else {
+            activeGradientNum++;
+        }
+        setHoverGradient();
+        positionHoverGradient(event);
+    }
+
+})();

--- a/assets/js/logo/logo-script5.js
+++ b/assets/js/logo/logo-script5.js
@@ -1,0 +1,91 @@
+(function() {
+    var hoverGradients = ['logo-radial-gradient0', 'logo-radial-gradient1', 'logo-radial-gradient2'];
+    var hoverGradientEls = {
+        'logo-radial-gradient0': document.getElementById('logo-radial-gradient0'),
+        'logo-radial-gradient1': document.getElementById('logo-radial-gradient1'),
+        'logo-radial-gradient2': document.getElementById('logo-radial-gradient2')
+    };
+    var logoMaskBox = document.getElementById('logo-mask-box');
+    var logoStrokeBox = document.getElementById('logo-stroke-box');
+    var bryan = document.getElementById('Bryan');
+    var braun = document.getElementById('Braun');
+    var lettersBryan = Array.from(bryan.children);
+    var lettersBraun = Array.from(braun.children);
+    var DEFAULT_FILL_VALUE = 'url(#logo-linear-gradient)';
+    var activeGradientNum = 0;
+
+    var xDestination = ['-20vw', '-10vw', '0', '10vw', '20vw'];
+    var yDestination = ['15vh', '37.5vh', '50vh', '37.5vh', '15vh'];
+
+    logoMaskBox.addEventListener('mouseenter', setHoverGradient);
+    logoMaskBox.addEventListener('mousemove', positionHoverGradient);
+    logoMaskBox.addEventListener('mouseleave', setDefaultGradient);
+    logoMaskBox.addEventListener('click', toggleGradient);
+    logoMaskBox.addEventListener('mouseenter', startSizeAnimation);
+    logoMaskBox.addEventListener('mouseleave', stopSizeAnimation);
+
+    function startSizeAnimation() {
+        lettersBryan.forEach(function (letter, key) {
+            letter.style.transform = 'translate('+xDestination[key]+',-'+yDestination[key]+')';
+            letter.style.transition = 'transform 1s';
+        });
+        lettersBraun.forEach(function (letter, key) {
+            letter.style.transform = 'translate('+xDestination[key]+','+yDestination[key]+')';
+            letter.style.transition = "transform 1s";
+        });
+    }
+
+    function stopSizeAnimation() {
+        lettersBryan.forEach(function (letter) {
+            letter.style.transform = 'translate(0,0)';
+            letter.style.transition = "transform 0.75s";
+        });
+        lettersBraun.forEach(function (letter) {
+            letter.style.transform = 'translate(0,0)';
+            letter.style.transition = "transform 0.75s";
+        });
+    }
+
+    function getHoverFillValue() {
+        return 'url(#' + hoverGradients[activeGradientNum] + ')';
+    }
+
+    function positionHoverGradient(event) {
+        var currentGradientEl = hoverGradientEls[hoverGradients[activeGradientNum]],
+            clientRect = logoMaskBox.getBoundingClientRect(),
+            svgX = event.x - clientRect.left,
+            svgY = event.y - clientRect.top,
+            percentX = Math.round(100 * (svgX / clientRect.width)),
+            percentY = Math.round(100 * (svgY / clientRect.height));
+
+        /**
+         * We set percentages instead of units because that
+         * works best across various SVG scaling scenarios.
+         */
+        currentGradientEl.fx.baseVal.valueAsString = '' + percentX + '%';
+        currentGradientEl.fy.baseVal.valueAsString = '' + percentY + '%';
+        currentGradientEl.cx.baseVal.valueAsString = '' + percentX + '%';
+        currentGradientEl.cy.baseVal.valueAsString = '' + percentY + '%';
+    }
+
+    function setHoverGradient() {
+        logoMaskBox.style.fill = getHoverFillValue();
+        logoStrokeBox.style.stroke = getHoverFillValue();
+    }
+
+    function setDefaultGradient(event) {
+        logoMaskBox.style.fill = DEFAULT_FILL_VALUE;
+        logoStrokeBox.style.stroke = DEFAULT_FILL_VALUE;
+    }
+
+    function toggleGradient(event) {
+        if (activeGradientNum === hoverGradients.length - 1) {
+            activeGradientNum = 0;
+        } else {
+            activeGradientNum++;
+        }
+        setHoverGradient();
+        positionHoverGradient(event);
+    }
+
+})();


### PR DESCRIPTION
See #25

Changes the logo setup to be a single inline SVG with a random script file instead, including a test page.

(I gave up trying to build `jekyll-gh-pages` locally after nokogiri complained about libxml2 for the second hour in succession. This is an attempt to make my repo on GitHub build it, since this is all their fault anyway.)