### PR TITLE
Omit focal point positioning attributes

### DIFF
--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -7,17 +7,17 @@
       <desc id="desc">Logo</desc>
 
       <defs>
-        <radialGradient id="logo-radial-gradient0" fx=".5" fy="0" cx=".5" cy="0" r=".5">
+        <radialGradient id="logo-radial-gradient0" cx=".5" cy="0" r=".5">
           <stop offset="0" stop-color="#99CCDD" stop-opacity="1"/>
           <stop offset="1" stop-color="#5599AA" stop-opacity="1" />
         </radialGradient>
 
-        <radialGradient id="logo-radial-gradient1" fx=".5" fy="0" cx=".5" cy="0" r=".9">
+        <radialGradient id="logo-radial-gradient1" cx=".5" cy="0" r=".9">
           <stop offset="0" stop-color="#99CCDD" stop-opacity="1"/>
           <stop offset="1" stop-color="#111039" stop-opacity="1" />
         </radialGradient>
 
-        <radialGradient id="logo-radial-gradient2" fx=".5" fy="0" cx=".5" cy="0" r=".9">
+        <radialGradient id="logo-radial-gradient2" cx=".5" cy="0" r=".9">
           <stop offset="0"  stop-color="#72EC82" stop-opacity="1"/>
           <stop offset=".5" stop-color="#3D8358" stop-opacity="1" />
           <stop offset="1"  stop-color="#224A57" stop-opacity="1" />

--- a/assets/js/logo/logo-script1.js
+++ b/assets/js/logo/logo-script1.js
@@ -31,8 +31,6 @@
      * We set unitless numbers because that
      * works best across various SVG scaling scenarios.
      */
-    currentGradientEl.fx.baseVal.value = percentX;
-    currentGradientEl.fy.baseVal.value = percentY;
     currentGradientEl.cx.baseVal.value = percentX;
     currentGradientEl.cy.baseVal.value = percentY;
   }

--- a/assets/js/logo/logo-script2.js
+++ b/assets/js/logo/logo-script2.js
@@ -64,8 +64,6 @@
      * We set unitless numbers because that
      * works best across various SVG scaling scenarios.
      */
-    currentGradientEl.fx.baseVal.value = percentX;
-    currentGradientEl.fy.baseVal.value = percentY;
     currentGradientEl.cx.baseVal.value = percentX;
     currentGradientEl.cy.baseVal.value = percentY;
   }

--- a/assets/js/logo/logo-script3.js
+++ b/assets/js/logo/logo-script3.js
@@ -79,8 +79,6 @@
      * We set unitless numbers because that
      * works best across various SVG scaling scenarios.
      */
-    currentGradientEl.fx.baseVal.value = percentX;
-    currentGradientEl.fy.baseVal.value = percentY;
     currentGradientEl.cx.baseVal.value = percentX;
     currentGradientEl.cy.baseVal.value = percentY;
   }

--- a/assets/js/logo/logo-script4.js
+++ b/assets/js/logo/logo-script4.js
@@ -52,8 +52,6 @@
          * We set unitless numbers because that
          * works best across various SVG scaling scenarios.
          */
-        currentGradientEl.fx.baseVal.value = percentX;
-        currentGradientEl.fy.baseVal.value = percentY;
         currentGradientEl.cx.baseVal.value = percentX;
         currentGradientEl.cy.baseVal.value = percentY;
     }

--- a/assets/js/logo/logo-script5.js
+++ b/assets/js/logo/logo-script5.js
@@ -62,8 +62,6 @@
          * We set unitless numbers because that
          * works best across various SVG scaling scenarios.
          */
-        currentGradientEl.fx.baseVal.value = percentX;
-        currentGradientEl.fy.baseVal.value = percentY;
         currentGradientEl.cx.baseVal.value = percentX;
         currentGradientEl.cy.baseVal.value = percentY;
     }


### PR DESCRIPTION
[`fx` and `fy` are assumed to be the same as `cx` and `cy` if unspecified.](https://www.w3.org/TR/SVG/pservers.html#RadialGradientElementFXAttribute) We never have them differ, so we can remove those attributes and the JavaScript that sets them.