### PR TITLE
Omit unnecessary radial gradient positioning attributes

### DIFF
--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -7,17 +7,17 @@
       <desc id="desc">Logo</desc>
 
       <defs>
-        <radialGradient id="logo-radial-gradient0" cx=".5" cy="0" r=".5">
+        <radialGradient id="logo-radial-gradient0" cy="0">
           <stop offset="0" stop-color="#9cd"/>
           <stop offset="1" stop-color="#59a"/>
         </radialGradient>
 
-        <radialGradient id="logo-radial-gradient1" cx=".5" cy="0" r=".9">
+        <radialGradient id="logo-radial-gradient1" cy="0" r=".9">
           <stop offset="0" stop-color="#9cd"/>
           <stop offset="1" stop-color="#111039"/>
         </radialGradient>
 
-        <radialGradient id="logo-radial-gradient2" cx=".5" cy="0" r=".9">
+        <radialGradient id="logo-radial-gradient2" cy="0" r=".9">
           <stop offset="0"  stop-color="#72eC82"/>
           <stop offset=".5" stop-color="#3D8358"/>
           <stop offset="1"  stop-color="#224a57"/>


### PR DESCRIPTION
[`cx`, `cy`, and `r` default to `50%`/`.5` if unspecified.](https://www.w3.org/TR/SVG/pservers.html#RadialGradientElementCXAttribute)