### PR TITLE
Capture `change` instead of `submit` event

### DIFF
--- a/_pages/logo-dev.html
+++ b/_pages/logo-dev.html
@@ -23,10 +23,6 @@ permalink: /logo-dev/
     </p>
     {% endfor %}
   </fieldset>
-
-  <p>
-    <button>Run Code</button>
-  </p>
 </form>
 
 <script>
@@ -50,10 +46,11 @@ permalink: /logo-dev/
       svgEl.innerHTML = temp;
     }
 
-    formEl.addEventListener('submit', function (event) {
+    formEl.addEventListener('change', function (event) {
       cleanEventListeners();
       executeScript();
-      event.preventDefault();
     });
+
+    executeScript();
   })(document);
 </script>


### PR DESCRIPTION
For some reason, after calling `preventDefault()` on a `submit` event, the form isn't emitting the `submit` event again.

I'm too tired to comb through the HTML5 spec to find out the doubtless-ridiculous reason why this is.